### PR TITLE
Refs #34784 -- Added fr_CA format variant.

### DIFF
--- a/django/conf/locale/fr_CA/formats.py
+++ b/django/conf/locale/fr_CA/formats.py
@@ -1,0 +1,30 @@
+# This file is distributed under the same license as the Django package.
+#
+# The *_FORMAT strings use the Django date format syntax,
+# see https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
+DATE_FORMAT = "j F Y"  # 31 janvier 2024
+TIME_FORMAT = "H\xa0h\xa0i"  # 13 h 40
+DATETIME_FORMAT = "j F Y, H\xa0\h\xa0i" # 31 janvier 2024, 13 h 40
+YEAR_MONTH_FORMAT = "F Y"
+MONTH_DAY_FORMAT = "j F"
+SHORT_DATE_FORMAT = "Y-m-d"
+SHORT_DATETIME_FORMAT = "Y-m-d H\xa0\h\xa0i"
+FIRST_DAY_OF_WEEK = 1  # Lundi
+
+# The *_INPUT_FORMATS strings use the Python strftime format syntax,
+# see https://docs.python.org/library/datetime.html#strftime-strptime-behavior
+DATE_INPUT_FORMATS = [
+    "%Y-%m-%d",  # '2006-05-15'
+    "%y-%m-%d",  # '06-05-15'
+]
+DATETIME_INPUT_FORMATS = [
+    "%Y-%m-%d %H:%M:%S",  # '2006-05-15 14:30:57'
+    "%y-%m-%d %H:%M:%S",  # '06-05-15 14:30:57'
+    "%Y-%m-%d %H:%M:%S.%f",  # '2006-05-15 14:30:57.000200'
+    "%y-%m-%d %H:%M:%S.%f",  # '06-05-15 14:30:57.000200'
+    "%Y-%m-%d %H:%M",  # '2006-05-15 14:30'
+    "%y-%m-%d %H:%M",  # '06-05-15 14:30'
+]
+DECIMAL_SEPARATOR = ","
+THOUSAND_SEPARATOR = "\xa0"  # non-breaking space
+NUMBER_GROUPING = 3


### PR DESCRIPTION
Salut Claude, voici la variante Canadienne française selon ces sources tel que demandé sur django/django#17187

- https://www.btb.termiumplus.gc.ca/tpv2guides/guides/clefsfp/index-fra.html?lang=fra&lettr=indx_catlog_d&page=9lcOojjUrxt8.html
- https://vitrinelinguistique.oqlf.gouv.qc.ca/21241/la-typographie/nombres/ecriture-des-dates-et-des-heures-dans-certains-contextes-techniques
- https://en.wikipedia.org/wiki/Date_and_time_notation_in_Canada
- https://metacpan.org/dist/DateTime-Locale/view/lib/DateTime/Locale/fr_CA.pod